### PR TITLE
fix: migrate Chrome background to MV3 and package loadable builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Verify extension
         run: vp run check
+
+      - name: Build extension packages
+        run: vp run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 .claude/worktrees/
+dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,16 +17,25 @@
 - `pnpm install`
 - `pnpm run check`
 - `pnpm run format`
+- `pnpm run build` — emit loadable `dist/chrome/` and `dist/firefox/` plus store zips
 
 ## Repo-Specific Guidance
 
 - Keep `README.md` user-facing and move contributor workflow to `CONTRIBUTING.md`
 - Keep Chrome and Firefox manifests aligned when extension metadata or permissions change
-- Prefer simple background-script changes over adding build tooling to this repo
+- `package.json` `version` is the single version source; `scripts/build.mjs` stamps it
+  into the emitted manifests, so the tracked `src/manifest.*.json` files carry no version
+- Chrome uses MV3 (`background.service_worker`, `action`); Firefox stays MV2
+  (`background.scripts`, `browser_action`). `src/background.js` must keep working in both:
+  register listeners at top level and keep state in `browser.storage`, not globals
+- Keep packaging limited to `scripts/build.mjs`; prefer simple background-script changes
+  over adding heavier build tooling
 - Update docs when install paths, store links, or local testing steps change
 
 ## Validation
 
 - Run `pnpm run check` when changing docs, manifests, locale messages, or the background script
-- Manually load the unpacked extension from `src/` in the affected browser when behavior changes
-- CI runs the same check on pull requests and `main`
+- Run `pnpm run build`, then load the built extension in the affected browser when behavior changes:
+  - Chrome: `chrome://extensions` → Developer mode → Load unpacked → `dist/chrome/`
+  - Firefox: `about:debugging#/runtime/this-firefox` → Load Temporary Add-on → `dist/firefox/manifest.json`
+- CI runs the same check and build on pull requests and `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,20 @@ pnpm install
 
 ## Local Testing
 
-This repo does not build artifacts. Load the unpacked extension directly from `src/`.
+Build the per-browser directories first:
 
-- Chrome: load `src/manifest.chrome.json` through the unpacked-extension flow
-- Firefox: load `src/manifest.firefox.json` through temporary add-on loading
+```bash
+pnpm run build
+```
+
+This emits `dist/chrome/` and `dist/firefox/` (each with a `manifest.json`) plus a store
+zip per browser under `dist/`.
+
+- Chrome: `chrome://extensions` → enable Developer mode → Load unpacked → select `dist/chrome/`
+- Firefox: `about:debugging#/runtime/this-firefox` → Load Temporary Add-on → select `dist/firefox/manifest.json`
+
+`package.json` `version` is the single version source; the build stamps it into each
+emitted `manifest.json`. Do not add a `version` field to `src/manifest.*.json`.
 
 ## Validation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "putio-webextension",
-  "version": "2.3.3",
+  "version": "3.1.0",
   "description": "Download links to put.io with right-click in browsers",
   "keywords": [],
   "homepage": "https://github.com/putdotio/putio-webextension#readme",
@@ -15,6 +15,7 @@
   },
   "main": "src/background.js",
   "scripts": {
+    "build": "node scripts/build.mjs",
     "check": "vp check .",
     "format": "vp check --fix ."
   },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,54 @@
+// Emits a loadable unpacked directory and a store zip per browser:
+//   dist/<browser>/                                 -> load unpacked / temporary add-on
+//   dist/putio-webextension-<browser>-<version>.zip -> store upload
+//
+// package.json `version` is the single version source; it is stamped into
+// each emitted manifest.json here. The tracked src/manifest.*.json files
+// intentionally carry no version field.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const srcDir = path.join(root, "src");
+const distDir = path.join(root, "dist");
+
+const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+const browsers = ["chrome", "firefox"];
+
+fs.rmSync(distDir, { recursive: true, force: true });
+
+for (const browser of browsers) {
+  const outDir = path.join(distDir, browser);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  for (const entry of fs.readdirSync(srcDir)) {
+    if (/^manifest\..+\.json$/.test(entry)) {
+      continue;
+    }
+
+    fs.cpSync(path.join(srcDir, entry), path.join(outDir, entry), {
+      recursive: true,
+    });
+  }
+
+  const manifestPath = path.join(srcDir, `manifest.${browser}.json`);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  manifest.version = pkg.version;
+  fs.writeFileSync(path.join(outDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+
+  const zipName = `putio-webextension-${browser}-${pkg.version}.zip`;
+  const zip = spawnSync("zip", ["-qr", path.join("..", zipName), "."], {
+    cwd: outDir,
+    stdio: "inherit",
+  });
+
+  if (zip.error || zip.status !== 0) {
+    console.error(`zip failed for ${browser}:`, zip.error ?? `exit ${zip.status}`);
+    process.exit(1);
+  }
+
+  console.log(`built dist/${browser}/ and dist/${zipName}`);
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -5,6 +5,9 @@
 // package.json `version` is the single version source; it is stamped into
 // each emitted manifest.json here. The tracked src/manifest.*.json files
 // intentionally carry no version field.
+//
+// Requires the external `zip` binary on PATH (preinstalled on macOS and
+// ubuntu-latest CI runners).
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -44,6 +47,11 @@ for (const browser of browsers) {
     cwd: outDir,
     stdio: "inherit",
   });
+
+  if (zip.error?.code === "ENOENT") {
+    console.error("`zip` binary not found on PATH; install it and re-run `pnpm run build`");
+    process.exit(1);
+  }
 
   if (zip.error || zip.status !== 0) {
     console.error(`zip failed for ${browser}:`, zip.error ?? `exit ${zip.status}`);

--- a/src/background.js
+++ b/src/background.js
@@ -120,7 +120,15 @@ function startAuthFlow() {
 }
 
 function handleAuthCallback(redirectURL) {
-  var token = redirectURL.split("#access_token=")[1];
+  // Cancellation rejects the promise (handled by the caller's catch); this
+  // guards a completed flow whose redirect carries no access token.
+  var token = redirectURL && redirectURL.split("#access_token=")[1];
+
+  if (!token) {
+    console.error("PutioWebExtension - Auth flow returned no access token");
+    return;
+  }
+
   return validateToken(token, { notify: true });
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,6 @@
-// to be platform independent
+// Firefox provides the promise-based `browser` namespace; Chrome MV3
+// service workers only provide `chrome`, which returns promises for the
+// APIs used here.
 if (typeof browser === "undefined") {
   var browser = chrome;
 }
@@ -6,15 +8,98 @@ if (typeof browser === "undefined") {
 var clientID = "2939";
 var apiURL = "https://api.put.io/v2";
 var appURL = "https://app.put.io";
-var notificationIcon = browser.runtime.getURL("icon-notify.png");
 
-browser.storage.local.get().then((storage) => {
-  if (!storage.token) {
-    return startAuthFlow();
+// MV3 renamed the MV2 `browserAction` toolbar API to `action`.
+var toolbarAction = browser.action || browser.browserAction;
+
+// Chrome MV3 stops and restarts the service worker between events:
+// every listener is registered at the top level, and state (the token)
+// lives in browser.storage instead of globals.
+
+browser.runtime.onInstalled.addListener(initialize);
+browser.runtime.onStartup.addListener(initialize);
+
+browser.contextMenus.onClicked.addListener(function (item, tab) {
+  var link;
+
+  if (item.menuItemId === "download-link") {
+    link = item.linkUrl;
   }
 
-  return validateToken(storage.token, { notify: false });
+  if (item.menuItemId === "download-page") {
+    link = tab.url;
+  }
+
+  if (!link) {
+    return;
+  }
+
+  getToken().then(function (token) {
+    if (!token) {
+      return startAuthFlow();
+    }
+
+    return startTransfer(token, link);
+  });
 });
+
+browser.notifications.onClicked.addListener(function (notificationId) {
+  if (notificationId === "transfer-start") {
+    browser.tabs.create({
+      active: true,
+      url: appURL + "/transfers",
+    });
+  }
+
+  browser.notifications.clear(notificationId);
+});
+
+toolbarAction.onClicked.addListener(function () {
+  browser.tabs.create({
+    active: true,
+    url: appURL,
+  });
+});
+
+function initialize() {
+  createContextMenus();
+
+  getToken().then(function (token) {
+    if (!token) {
+      return startAuthFlow();
+    }
+
+    return validateToken(token, { notify: false });
+  });
+}
+
+function createContextMenus() {
+  createContextMenuItem({
+    id: "download-link",
+    title: browser.i18n.getMessage("downloadMenuItem"),
+    contexts: ["link"],
+  });
+
+  createContextMenuItem({
+    id: "download-page",
+    title: browser.i18n.getMessage("downloadPageMenuItem"),
+    contexts: ["page"],
+  });
+}
+
+function createContextMenuItem(properties) {
+  browser.contextMenus.create(properties, function () {
+    // Menus persist across service-worker restarts in Chrome; reading
+    // lastError swallows the duplicate-id error on re-creation.
+    void browser.runtime.lastError;
+  });
+}
+
+function getToken() {
+  return browser.storage.local.get("token").then(function (storage) {
+    return storage.token;
+  });
+}
 
 function startAuthFlow() {
   var redirectURL = browser.identity.getRedirectURL();
@@ -23,22 +108,24 @@ function startAuthFlow() {
   authURL += "&response_type=token";
   authURL += "&redirect_uri=" + encodeURIComponent(redirectURL);
 
-  return browser.identity.launchWebAuthFlow(
-    {
+  return browser.identity
+    .launchWebAuthFlow({
       interactive: true,
       url: authURL,
-    },
-    handleAuthCallback,
-  );
+    })
+    .then(handleAuthCallback)
+    .catch(function (error) {
+      console.error("PutioWebExtension - Auth flow failed: ", error);
+    });
 }
 
 function handleAuthCallback(redirectURL) {
   var token = redirectURL.split("#access_token=")[1];
-  validateToken(token, { notify: true });
+  return validateToken(token, { notify: true });
 }
 
 function validateToken(token, options) {
-  fetch(apiURL + "/oauth2/validate", {
+  return fetch(apiURL + "/oauth2/validate", {
     headers: {
       authorization: "token " + token,
     },
@@ -61,15 +148,8 @@ function validateTokenSuccess(token, options) {
   });
 
   if (options && options.notify) {
-    browser.notifications.create("validate-success", {
-      type: "basic",
-      iconUrl: notificationIcon,
-      title: browser.i18n.getMessage("welcomeNotificationTitle"),
-      message: browser.i18n.getMessage("welcomeNotificationMessage"),
-    });
+    notify("validate-success", "welcomeNotificationTitle", "welcomeNotificationMessage");
   }
-
-  return boot(token);
 }
 
 function validateTokenFailure(error) {
@@ -77,84 +157,46 @@ function validateTokenFailure(error) {
   return startAuthFlow();
 }
 
-function boot(token) {
-  function startTransfer(link) {
-    browser.notifications.create("transfer-start", {
-      type: "basic",
-      iconUrl: notificationIcon,
-      title: browser.i18n.getMessage("transferStartNotificationTitle"),
-      message: browser.i18n.getMessage("transferStartNotificationMessage"),
-    });
+function startTransfer(token, link) {
+  notify("transfer-start", "transferStartNotificationTitle", "transferStartNotificationMessage");
 
-    fetch(apiURL + "/transfers/add", {
-      method: "POST",
-      body: JSON.stringify({ url: link }),
-      headers: {
-        Authorization: "token " + token,
-        "content-type": "application/json; charset=utf-8",
-      },
+  return fetch(apiURL + "/transfers/add", {
+    method: "POST",
+    body: JSON.stringify({ url: link }),
+    headers: {
+      Authorization: "token " + token,
+      "content-type": "application/json; charset=utf-8",
+    },
+  })
+    .then(function (response) {
+      if (response.ok) {
+        return startTransferSuccess();
+      }
+
+      return startTransferFailure(response);
     })
-      .then(function (response) {
-        if (response.ok) {
-          return startTransferSuccess();
-        }
+    .catch(startTransferFailure);
+}
 
-        return startTransferFailure(response);
-      })
-      .catch(startTransferFailure);
-  }
+function startTransferSuccess() {
+  console.log("PutioWebExtension - Transfer started!");
+}
 
-  function startTransferSuccess() {
-    console.log("PutioWebExtension - Transfer started!");
-  }
+function startTransferFailure(error) {
+  console.error("PutioWebExtension - Transfer failed: ", error);
 
-  function startTransferFailure(error) {
-    console.error("PutioWebExtension - Transfer failed: ", error);
+  notify(
+    "transfer-start-failure",
+    "transferFailureNotificationTitle",
+    "transferFailureNotificationMessage",
+  );
+}
 
-    browser.notifications.create("transfer-start-failure", {
-      type: "basic",
-      iconUrl: notificationIcon,
-      title: browser.i18n.getMessage("transferFailureNotificationTitle"),
-      message: browser.i18n.getMessage("transferFailureNotificationMessage"),
-    });
-  }
-
-  browser.contextMenus.create({
-    id: "download-link",
-    title: browser.i18n.getMessage("downloadMenuItem"),
-    contexts: ["link"],
-  });
-
-  browser.contextMenus.create({
-    id: "download-page",
-    title: browser.i18n.getMessage("downloadPageMenuItem"),
-    contexts: ["page"],
-  });
-
-  browser.contextMenus.onClicked.addListener((item, tab) => {
-    if (item.menuItemId === "download-link") {
-      startTransfer(item.linkUrl);
-    }
-    if (item.menuItemId === "download-page") {
-      startTransfer(tab.url);
-    }
-  });
-
-  browser.notifications.onClicked.addListener(function (notificationId) {
-    if (notificationId === "transfer-start") {
-      browser.tabs.create({
-        active: true,
-        url: appURL + "/transfers",
-      });
-    }
-
-    browser.notifications.clear(notificationId);
-  });
-
-  browser.browserAction.onClicked.addListener(function () {
-    browser.tabs.create({
-      active: true,
-      url: appURL,
-    });
+function notify(id, titleKey, messageKey) {
+  browser.notifications.create(id, {
+    type: "basic",
+    iconUrl: browser.runtime.getURL("icon-notify.png"),
+    title: browser.i18n.getMessage(titleKey),
+    message: browser.i18n.getMessage(messageKey),
   });
 }

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": 3,
+  "minimum_chrome_version": "105",
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -2,7 +2,6 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "3.0.1",
   "default_locale": "en",
   "homepage_url": "https://github.com/putdotio/putio-webextension",
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCBY/vZ2HE8Vul6TqZA+q/c5ZLEWLWkk4Cd5tz5RHBi2DqMvty/evWUtQgZ3XVDKLGAA+KU1YYDc9UKR4WJ+UBmIos+rJHKWl/gm4ClCn2EUsAk3JtucexhFFc6DZzMCyH+ZAn5103eCozVCYV6C+9HDrgeBJyRc8HIDDy2i+mAzwIDAQAB",
@@ -16,6 +15,6 @@
     "128": "icon128.png"
   },
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   }
 }

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -2,7 +2,6 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "3.0.2",
   "default_locale": "en",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
Fixes #16 (WS0 of putdotio/putio-frontend#24).

## Problem

- `src/manifest.chrome.json` declared `manifest_version: 3` but used MV2 `background.scripts`; Chrome MV3 requires `background.service_worker`, so the shipped background never ran as declared
- `src/background.js:154` called `browser.browserAction.onClicked` (MV2 API) while the Chrome manifest declares `action`
- Listeners were registered inside `boot()` after an async token check, so an MV3 service worker restarting on an event would miss them; the token lived in a closure
- Versions disagreed three ways: package.json `2.3.3`, chrome manifest `3.0.1`, firefox manifest `3.0.2`
- The documented proof path ("load unpacked from `src/`") could not run: no directory contains a literal `manifest.json`

## Solution

- Chrome manifest: `background.service_worker`. Firefox stays MV2 (`background.scripts` + `browser_action`), unchanged semantically
- `background.js` rewritten for MV3 service-worker constraints, still shared across both browsers: all listeners registered at top level, token read from `browser.storage` inside handlers instead of a boot-time closure, `browser.action || browser.browserAction` for the toolbar click, context menus created on `onInstalled`/`onStartup` with duplicate-id errors swallowed via `runtime.lastError`
- Version source of truth: package.json `3.1.0` (next after the highest store version 3.0.2). `scripts/build.mjs` stamps it into the emitted manifests; the tracked `src/manifest.*.json` files carry no `version` field, so a triple mismatch cannot recur
- `pnpm run build` (dependency-free Node script, no new tooling) emits loadable `dist/chrome/` and `dist/firefox/` plus `dist/putio-webextension-<browser>-<version>.zip` store zips; CI runs it after `check`; AGENTS.md and CONTRIBUTING.md document the real load steps

## Proof

- `pnpm run check`: pass (14 files formatted, 0 lint errors)
- `pnpm run build`: emits both directories and zips, version `3.1.0` stamped
- Chrome: loaded `dist/chrome/` in headless Chromium (Playwright, `--load-extension`); service worker registered at the store extension ID `gmlaklldebhgnhfoppklejnjcmndcehf` (key preserved), `chrome.runtime.getManifest()` returned MV3/3.1.0, and `action`/`contextMenus`/`notifications` `onClicked.hasListeners()` all true; screenshot of `chrome://extensions` below
- Firefox: not runtime-loaded — Playwright's Firefox build cannot install temporary add-ons headlessly. Validated instead by structure: emitted `manifest.json` is MV2 with `background.scripts`, `browser_action`, and version 3.1.0, and the zip contains all assets at the root. Manual `about:debugging` load still recommended before a store release

![put.io extension loaded at chrome://extensions, MV3 build 3.1.0](https://attach.uinaf.dev/o/q0due9tgd1hZ8DJfgrsX4A)

[Full-size preview](https://attach.uinaf.dev/p/q0due9tgd1hZ8DJfgrsX4A)
