### PR TITLE
chore: modernize package metadata, GitHub templates, and fix Dependabot postcss failure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,37 @@
+name: Bug report
+description: Report a reproducible problem with the put.io browser extension.
+title: ""
+labels:
+  - bug
+body:
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Exact steps, including the page and the link or media you right-clicked.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser and version, extension version, and whether it was installed from the store or loaded unpacked.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Screenshots or console output. Do not include put.io tokens or account credentials.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Suggest an improvement to the put.io browser extension.
+title: ""
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: State the outcome you need, not the proposed implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Current workaround
+      description: How you solve this today, if at all.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Summary
+
+## Verification
+
+## Notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ pnpm run build
 ```
 
 This emits `dist/chrome/` and `dist/firefox/` (each with a `manifest.json`) plus a store
-zip per browser under `dist/`.
+zip per browser under `dist/`. Zipping requires the external `zip` binary on PATH
+(preinstalled on macOS and the Ubuntu CI runners).
 
 - Chrome: `chrome://extensions` → enable Developer mode → Load unpacked → select `dist/chrome/`
 - Firefox: `about:debugging#/runtime/this-firefox` → Load Temporary Add-on → select `dist/firefox/manifest.json`
@@ -33,10 +34,12 @@ Before opening a pull request:
 
 ```bash
 pnpm run check
+pnpm run build
 ```
 
-If the change affects runtime behavior, manually exercise the right-click flow in the affected browser.
-CI runs the same check on pull requests and `main`.
+If the change affects runtime behavior, load the built extension from `dist/` and manually
+exercise the right-click flow in the affected browser.
+CI runs the same check and build on pull requests and `main`.
 
 ## Development Notes
 

--- a/package.json
+++ b/package.json
@@ -2,13 +2,22 @@
   "name": "putio-webextension",
   "version": "3.1.0",
   "description": "Download links to put.io with right-click in browsers",
-  "keywords": [],
+  "keywords": [
+    "browser-extension",
+    "chrome-extension",
+    "context-menu",
+    "download",
+    "firefox-addon",
+    "put.io",
+    "putio",
+    "webextension"
+  ],
   "homepage": "https://github.com/putdotio/putio-webextension#readme",
   "bugs": {
     "url": "https://github.com/putdotio/putio-webextension/issues"
   },
-  "license": "ISC",
-  "author": "",
+  "license": "MIT",
+  "author": "put.io <devs@put.io>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/putdotio/putio-webextension.git"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -769,8 +769,8 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -822,8 +822,8 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -1209,7 +1209,7 @@ snapshots:
       '@oxc-project/runtime': 0.143.0
       '@oxc-project/types': 0.143.0
       lightningcss: 1.33.0
-      postcss: 8.5.16
+      postcss: 8.5.26
       yuku-codegen: 0.5.48
       yuku-parser: 0.5.48
     optionalDependencies:
@@ -1409,7 +1409,7 @@ snapshots:
 
   mrmime@2.0.1: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.18: {}
 
   obug@2.1.3: {}
 
@@ -1479,9 +1479,9 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  postcss@8.5.16:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

Fixes #18

- `package.json`: `license` now matches the MIT LICENSE file; filled `keywords` (8 store terms) and `author` (`put.io <devs@put.io>`, matching sibling repos).
- Added `.github/pull_request_template.md` and YAML issue forms (bug + feature) with `blank_issues_enabled: false`, adapted from putio-cli.
- Fixed the recurring red Dependabot run on main: bumped transitive `postcss` 8.5.16 → 8.5.26 (+ its `nanoid` dep) in the lockfile.
- CONTRIBUTING.md: Validation now includes `pnpm run build` to match CI, and Local Testing names the external `zip` prerequisite. AGENTS.md already documents the #17 proof path end to end; no change needed there.

## Verification

- `pnpm run check` and `pnpm run build` pass locally; build emits `dist/chrome/`, `dist/firefox/`, and both store zips.
- `pnpm why postcss` resolves 8.5.26; `pnpm install --lockfile-only` accepts the lockfile with the `vite` override intact.

## Notes

Dependabot postcss root cause: the security job runs `corepack pnpm update postcss@8.5.26 --lockfile-only --no-save -r`, which is a **no-op while the `vite: "catalog:"` override is present** in `pnpm-workspace.yaml` (reproduced locally on pnpm 11.2.2 and 11.22.0; removing the override makes the same command succeed). Dependabot then reports "latest possible version that can be installed is 8.5.16" and the run fails. This PR re-resolved postcss with the override lifted and revalidated with it restored — no override change ships. 8.5.26 clears every open advisory range (worst is `<= 8.5.22`), so the security job stops firing. The pnpm override/update interaction is upstream; a future transitive advisory under the override would need the same manual bump.