### PR TITLE
fix: resume selected transfers after authentication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,9 @@ successful sign-in sends that link once. Try cancellation, a second click during
 and an expired credential. Temporary validation failures must not open repeated sign-in
 windows or discard an existing credential.
 
-The background script retains at most one selected link while recovering. Additional clicks
-leave it unchanged. Success, cancellation, and terminal failure clear it; abandoned records
+Ordinary signed-in downloads can run concurrently. The background script retains at most one
+selected link when authentication is needed; additional clicks during that recovery leave it
+unchanged. Success, cancellation, and terminal failure clear it; abandoned records
 expire before the next selected action after 15 minutes. A worker interrupted during a transfer POST
 cannot know whether the transfer started, so its notification opens the transfers page for
 checking and clears the saved action. It never automatically sends that uncertain request again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,10 @@ CI runs the same check and build on pull requests and `main`.
 With an isolated test browser profile, select a link while signed out and confirm that
 successful sign-in sends that link once. Try cancellation, a second click during sign-in,
 and an expired credential. Temporary validation failures must not open repeated sign-in
-windows or discard an existing credential.
+windows or discard an existing credential. If validation is unavailable after OAuth,
+the saved action retains its provisional token so an explicit retry validates that token
+without reopening sign-in. The token is not used for transfers until validation succeeds;
+it clears with the saved action on rejection or expiry.
 
 Ordinary signed-in downloads can run concurrently. The background script retains at most one
 selected link when authentication is needed; additional clicks during that recovery leave it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,9 @@ pnpm run check
 pnpm run build
 ```
 
+`check` includes deterministic background-flow tests using mocked browser and HTTP boundaries.
+Use `pnpm test` for the focused suite.
+
 If the change affects runtime behavior, load the built extension from `dist/` and manually
 exercise the right-click flow in the affected browser.
 CI runs the same check and build on pull requests and `main`.
@@ -53,3 +56,16 @@ CI runs the same check and build on pull requests and `main`.
 - Keep changes focused
 - Update both browser manifests when extension metadata should stay aligned
 - Include the browser flow you manually checked when behavior changes
+
+## Authentication recovery checks
+
+With an isolated test browser profile, select a link while signed out and confirm that
+successful sign-in sends that link once. Try cancellation, a second click during sign-in,
+and an expired credential. Temporary validation failures must not open repeated sign-in
+windows or discard an existing credential.
+
+The background script retains at most one selected link while recovering. Additional clicks
+leave it unchanged. Success, cancellation, and terminal failure clear it; abandoned records
+expire before the next selected action after 15 minutes. A worker interrupted during a transfer POST
+cannot know whether the transfer started, so its notification opens the transfers page for
+checking and clears the saved action. It never automatically sends that uncertain request again.

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   "main": "src/background.js",
   "scripts": {
     "build": "node scripts/build.mjs",
-    "check": "vp check .",
-    "format": "vp check --fix ."
+    "check": "vp check . && node --test",
+    "format": "vp check --fix .",
+    "test": "node --test"
   },
   "devDependencies": {
     "vite": "catalog:",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -40,27 +40,35 @@
     "description": "Description of the transfer failure notification"
   },
   "authUnavailableTitle": {
-    "message": "put.io is temporarily unavailable"
+    "message": "put.io is temporarily unavailable",
+    "description": "Notification title when sign-in validation cannot reach the service."
   },
   "authUnavailableMessage": {
-    "message": "We could not check your sign-in. Try again in a few minutes."
+    "message": "We could not check your sign-in. Try again in a few minutes.",
+    "description": "Recovery text after a temporary validation failure; stored credentials are retained."
   },
   "pendingTransferTitle": {
-    "message": "Finish your saved download"
+    "message": "Finish your saved download",
+    "description": "Notification title for the single link saved while sign-in is pending."
   },
   "pendingTransferMessage": {
-    "message": "A link is already waiting. Click to retry that link before choosing another."
+    "message": "A link is already waiting. Click to retry that link before choosing another.",
+    "description": "Clicking this notification retries the saved link; a new link has not replaced it."
   },
   "authCancelledTitle": {
-    "message": "Sign-in was not completed"
+    "message": "Sign-in was not completed",
+    "description": "Notification title after cancelled, rejected, or exhausted sign-in."
   },
   "authCancelledMessage": {
-    "message": "No transfer was started. Use the context menu to try again."
+    "message": "No transfer was started. Use the context menu to try again.",
+    "description": "The saved action was cleared without starting a transfer; choose the link again to retry."
   },
   "transferUncertainTitle": {
-    "message": "Check your transfers"
+    "message": "Check your transfers",
+    "description": "Notification title when the server may have accepted the download request."
   },
   "transferUncertainMessage": {
-    "message": "This download may already have started. Click to check your transfers before trying again."
+    "message": "This download may already have started. Click to check your transfers before trying again.",
+    "description": "Clicking opens transfers for inspection; the extension will not automatically resend this request."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -38,5 +38,29 @@
   "transferFailureNotificationMessage": {
     "message": "We are unable to download that :-/",
     "description": "Description of the transfer failure notification"
+  },
+  "authUnavailableTitle": {
+    "message": "put.io is temporarily unavailable"
+  },
+  "authUnavailableMessage": {
+    "message": "We could not check your sign-in. Try again in a few minutes."
+  },
+  "pendingTransferTitle": {
+    "message": "Finish your saved download"
+  },
+  "pendingTransferMessage": {
+    "message": "A link is already waiting. Click to retry that link before choosing another."
+  },
+  "authCancelledTitle": {
+    "message": "Sign-in was not completed"
+  },
+  "authCancelledMessage": {
+    "message": "No transfer was started. Use the context menu to try again."
+  },
+  "transferUncertainTitle": {
+    "message": "Check your transfers"
+  },
+  "transferUncertainMessage": {
+    "message": "This download may already have started. Click to check your transfers before trying again."
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -34,24 +34,27 @@ browser.contextMenus.onClicked.addListener(function (item, tab) {
     return;
   }
 
-  getToken().then(function (token) {
-    if (!token) {
-      return startAuthFlow();
-    }
-
-    return startTransfer(token, link);
+  return runOperation(function () {
+    return selectTransfer(link);
   });
 });
 
 browser.notifications.onClicked.addListener(function (notificationId) {
-  if (notificationId === "transfer-start") {
-    browser.tabs.create({
-      active: true,
-      url: appURL + "/transfers",
-    });
-  }
-
   browser.notifications.clear(notificationId);
+  if (notificationId === "transfer-start" || notificationId === "transfer-uncertain") {
+    browser.tabs.create({ active: true, url: appURL + "/transfers" });
+    if (notificationId === "transfer-uncertain") {
+      return runOperation(async function () {
+        var pending = await getPendingTransfer();
+        if (pending && pending.phase !== "ready") {
+          await browser.storage.local.remove("pendingTransfer");
+        }
+      });
+    }
+  }
+  if (notificationId === "auth-retry") {
+    return runOperation(resumeTransfer);
+  }
 });
 
 toolbarAction.onClicked.addListener(function () {
@@ -61,16 +64,28 @@ toolbarAction.onClicked.addListener(function () {
   });
 });
 
-function initialize() {
+async function initialize() {
   createContextMenus();
-
-  getToken().then(function (token) {
-    if (!token) {
-      return startAuthFlow();
+  var generation = operationGeneration;
+  try {
+    var pending = await getPendingTransfer(false);
+    if (pending) notifyPending(pending);
+    var token = await getToken();
+    if (!token) return;
+    var result = await validateToken(token);
+    // Startup validation must not block a click or invalidate a credential
+    // obtained by a user operation while this request was in flight.
+    if (result === "rejected" && generation === operationGeneration && !activeOperation) {
+      var currentToken = await getToken();
+      if (currentToken === token && generation === operationGeneration && !activeOperation) {
+        await browser.storage.local.remove("token");
+      }
+    } else if (result === "unavailable") {
+      notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
     }
-
-    return validateToken(token, { notify: false });
-  });
+  } catch {
+    notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
+  }
 }
 
 function createContextMenus() {
@@ -101,103 +116,183 @@ function getToken() {
   });
 }
 
-function startAuthFlow() {
+// The promise serializes this worker only. The selected link and send phase are
+// durable, so restarting an MV3 worker cannot replay an uncertain POST.
+var activeOperation = null;
+var operationGeneration = 0;
+var pendingMaxAge = 15 * 60 * 1000;
+
+function runOperation(operation) {
+  if (activeOperation) {
+    notify("auth-retry", "pendingTransferTitle", "pendingTransferMessage");
+    return activeOperation;
+  }
+  operationGeneration += 1;
+  activeOperation = Promise.resolve()
+    .then(operation)
+    .catch(function () {
+      notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
+    })
+    .finally(function () {
+      activeOperation = null;
+    });
+  return activeOperation;
+}
+
+async function getPendingTransfer(clearExpired = true) {
+  var storage = await browser.storage.local.get("pendingTransfer");
+  var pending = storage.pendingTransfer;
+  if (!pending) return null;
+  if (
+    typeof pending.link !== "string" ||
+    !pending.link ||
+    !Number.isFinite(pending.createdAt) ||
+    Date.now() - pending.createdAt > pendingMaxAge ||
+    ["ready", "sending", "uncertain"].indexOf(pending.phase) < 0
+  ) {
+    if (clearExpired) await browser.storage.local.remove("pendingTransfer");
+    return null;
+  }
+  return pending;
+}
+
+function savePendingTransfer(pending, phase) {
+  return browser.storage.local.set({
+    pendingTransfer: { link: pending.link, createdAt: pending.createdAt, phase: phase },
+  });
+}
+
+function notifyPending(pending) {
+  if (pending.phase === "ready") {
+    notify("auth-retry", "pendingTransferTitle", "pendingTransferMessage");
+  } else {
+    notify("transfer-uncertain", "transferUncertainTitle", "transferUncertainMessage");
+  }
+}
+
+async function selectTransfer(link) {
+  var pending = await getPendingTransfer();
+  if (pending && (pending.link !== link || pending.phase !== "ready")) {
+    notifyPending(pending);
+    return;
+  }
+  if (!pending) {
+    await savePendingTransfer({ link: link, createdAt: Date.now() }, "ready");
+  }
+  return resumeTransfer();
+}
+
+async function resumeTransfer() {
+  var pending = await getPendingTransfer();
+  if (!pending) return;
+  if (pending.phase !== "ready") {
+    notifyPending(pending);
+    return;
+  }
+  var token = await getToken();
+  var authenticated = false;
+  while (true) {
+    if (!token) {
+      if (authenticated) {
+        await browser.storage.local.remove("pendingTransfer");
+        notify("auth-cancelled", "authCancelledTitle", "authCancelledMessage");
+        return;
+      }
+      authenticated = true;
+      var auth = await startAuthFlow();
+      if (auth.state === "cancelled" || auth.state === "rejected") {
+        await browser.storage.local.remove("pendingTransfer");
+        notify("auth-cancelled", "authCancelledTitle", "authCancelledMessage");
+        return;
+      }
+      if (auth.state !== "ready") return;
+      token = auth.token;
+    }
+
+    // A terminated worker cannot tell whether this POST was accepted. Persist
+    // before sending, and require the user to check transfers after a restart.
+    await savePendingTransfer(pending, "sending");
+    var response = await startTransfer(token, pending.link);
+    if (response && response.ok) {
+      await browser.storage.local.remove("pendingTransfer");
+      return;
+    }
+    if (response && response.status === 401) {
+      await savePendingTransfer(pending, "ready");
+      await browser.storage.local.remove("token");
+      token = null;
+      continue;
+    }
+    if (!response || response.status >= 500) {
+      await savePendingTransfer(pending, "uncertain");
+      notify("transfer-uncertain", "transferUncertainTitle", "transferUncertainMessage");
+    } else {
+      await browser.storage.local.remove("pendingTransfer");
+      notify(
+        "transfer-start-failure",
+        "transferFailureNotificationTitle",
+        "transferFailureNotificationMessage",
+      );
+    }
+    return;
+  }
+}
+
+async function startAuthFlow() {
   var redirectURL = browser.identity.getRedirectURL();
   var authURL = apiURL + "/oauth2/authenticate";
   authURL += "?client_id=" + clientID;
   authURL += "&response_type=token";
   authURL += "&redirect_uri=" + encodeURIComponent(redirectURL);
+  var callback;
+  try {
+    callback = await browser.identity.launchWebAuthFlow({ interactive: true, url: authURL });
+  } catch {
+    return { state: "cancelled" };
+  }
+  var token;
+  try {
+    token = new URLSearchParams(new URL(callback).hash.slice(1)).get("access_token");
+  } catch {
+    return { state: "rejected" };
+  }
+  if (!token) return { state: "rejected" };
+  var result = await validateToken(token);
+  if (result !== "ready") {
+    notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
+    return { state: result };
+  }
+  await browser.storage.local.set({ token: token });
+  notify("validate-success", "welcomeNotificationTitle", "welcomeNotificationMessage");
+  return { state: "ready", token: token };
+}
 
-  return browser.identity
-    .launchWebAuthFlow({
-      interactive: true,
-      url: authURL,
-    })
-    .then(handleAuthCallback)
-    .catch(function (error) {
-      console.error("PutioWebExtension - Auth flow failed: ", error);
+async function validateToken(token) {
+  try {
+    var response = await fetch(apiURL + "/oauth2/validate", {
+      headers: { authorization: "token " + token },
     });
-}
-
-function handleAuthCallback(redirectURL) {
-  // Cancellation rejects the promise (handled by the caller's catch); this
-  // guards a completed flow whose redirect carries no access token.
-  var token = redirectURL && redirectURL.split("#access_token=")[1];
-
-  if (!token) {
-    console.error("PutioWebExtension - Auth flow returned no access token");
-    return;
-  }
-
-  return validateToken(token, { notify: true });
-}
-
-function validateToken(token, options) {
-  return fetch(apiURL + "/oauth2/validate", {
-    headers: {
-      authorization: "token " + token,
-    },
-  })
-    .then(function (response) {
-      if (response.ok) {
-        return validateTokenSuccess(token, options);
-      }
-
-      return validateTokenFailure(response);
-    })
-    .catch(validateTokenFailure);
-}
-
-function validateTokenSuccess(token, options) {
-  console.log("PutioWebExtension - Token validated!");
-
-  browser.storage.local.set({
-    token: token,
-  });
-
-  if (options && options.notify) {
-    notify("validate-success", "welcomeNotificationTitle", "welcomeNotificationMessage");
+    if (response.ok) return "ready";
+    return response.status === 401 ? "rejected" : "unavailable";
+  } catch {
+    return "unavailable";
   }
 }
 
-function validateTokenFailure(error) {
-  console.error("PutioWebExtension - Token validation failed: ", error);
-  return startAuthFlow();
-}
-
-function startTransfer(token, link) {
+async function startTransfer(token, link) {
   notify("transfer-start", "transferStartNotificationTitle", "transferStartNotificationMessage");
-
-  return fetch(apiURL + "/transfers/add", {
-    method: "POST",
-    body: JSON.stringify({ url: link }),
-    headers: {
-      Authorization: "token " + token,
-      "content-type": "application/json; charset=utf-8",
-    },
-  })
-    .then(function (response) {
-      if (response.ok) {
-        return startTransferSuccess();
-      }
-
-      return startTransferFailure(response);
-    })
-    .catch(startTransferFailure);
-}
-
-function startTransferSuccess() {
-  console.log("PutioWebExtension - Transfer started!");
-}
-
-function startTransferFailure(error) {
-  console.error("PutioWebExtension - Transfer failed: ", error);
-
-  notify(
-    "transfer-start-failure",
-    "transferFailureNotificationTitle",
-    "transferFailureNotificationMessage",
-  );
+  try {
+    return await fetch(apiURL + "/transfers/add", {
+      method: "POST",
+      body: JSON.stringify({ url: link }),
+      headers: {
+        Authorization: "token " + token,
+        "content-type": "application/json; charset=utf-8",
+      },
+    });
+  } catch {
+    return null;
+  }
 }
 
 function notify(id, titleKey, messageKey) {

--- a/src/background.js
+++ b/src/background.js
@@ -34,8 +34,8 @@ browser.contextMenus.onClicked.addListener(function (item, tab) {
     return;
   }
 
-  return runOperation(function () {
-    return selectTransfer(link);
+  return sendSelectedLink(link).catch(function () {
+    notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
   });
 });
 
@@ -43,14 +43,12 @@ browser.notifications.onClicked.addListener(function (notificationId) {
   browser.notifications.clear(notificationId);
   if (notificationId === "transfer-start" || notificationId === "transfer-uncertain") {
     browser.tabs.create({ active: true, url: appURL + "/transfers" });
-    if (notificationId === "transfer-uncertain") {
-      return runOperation(async function () {
-        var pending = await getPendingTransfer();
-        if (pending && pending.phase !== "ready") {
-          await browser.storage.local.remove("pendingTransfer");
-        }
-      });
-    }
+    return runOperation(async function () {
+      var pending = await getPendingTransfer();
+      if (pending && pending.phase !== "ready") {
+        await browser.storage.local.remove("pendingTransfer");
+      }
+    });
   }
   if (notificationId === "auth-retry") {
     return runOperation(resumeTransfer);
@@ -80,11 +78,13 @@ async function initialize() {
       if (currentToken === token && generation === operationGeneration && !activeOperation) {
         await browser.storage.local.remove("token");
       }
-    } else if (result === "unavailable") {
+    } else if (result === "unavailable" && generation === operationGeneration && !activeOperation) {
       notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
     }
   } catch {
-    notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
+    if (generation === operationGeneration && !activeOperation) {
+      notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
+    }
   }
 }
 
@@ -121,6 +121,36 @@ function getToken() {
 var activeOperation = null;
 var operationGeneration = 0;
 var pendingMaxAge = 15 * 60 * 1000;
+
+async function sendSelectedLink(link) {
+  operationGeneration += 1;
+  var token = await getToken();
+  var pending = (await browser.storage.local.get("pendingTransfer")).pendingTransfer;
+  if (!token || pending || activeOperation) {
+    return runOperation(function () {
+      return selectTransfer(link);
+    });
+  }
+
+  // Signed-in downloads can overlap, as before. Only a link needing auth
+  // recovery owns the durable slot; ordinary POSTs are never replayed.
+  var response = await startTransfer(token, link);
+  if (response && response.status === 401) {
+    return runOperation(async function () {
+      if ((await getToken()) === token) await browser.storage.local.remove("token");
+      return selectTransfer(link);
+    });
+  }
+  if (!response || response.status >= 500) {
+    notify("transfer-uncertain", "transferUncertainTitle", "transferUncertainMessage");
+  } else if (!response.ok) {
+    notify(
+      "transfer-start-failure",
+      "transferFailureNotificationTitle",
+      "transferFailureNotificationMessage",
+    );
+  }
+}
 
 function runOperation(operation) {
   if (activeOperation) {
@@ -259,7 +289,9 @@ async function startAuthFlow() {
   if (!token) return { state: "rejected" };
   var result = await validateToken(token);
   if (result !== "ready") {
-    notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
+    if (result === "unavailable") {
+      notify("auth-retry", "authUnavailableTitle", "authUnavailableMessage");
+    }
     return { state: result };
   }
   await browser.storage.local.set({ token: token });

--- a/src/background.js
+++ b/src/background.js
@@ -194,7 +194,9 @@ function getPendingTransfer(clearExpired = true) {
       !pending.link ||
       !Number.isFinite(pending.createdAt) ||
       Date.now() - pending.createdAt > pendingMaxAge ||
-      ["ready", "sending", "uncertain"].indexOf(pending.phase) < 0
+      ["ready", "sending", "uncertain"].indexOf(pending.phase) < 0 ||
+      (pending.provisionalToken !== undefined &&
+        (typeof pending.provisionalToken !== "string" || !pending.provisionalToken))
     ) {
       if (clearExpired) await browser.storage.local.remove("pendingTransfer");
       return null;
@@ -206,7 +208,14 @@ function getPendingTransfer(clearExpired = true) {
 function savePendingTransfer(pending, phase) {
   return updatePendingStorage(function () {
     return browser.storage.local.set({
-      pendingTransfer: { link: pending.link, createdAt: pending.createdAt, phase: phase },
+      pendingTransfer: {
+        link: pending.link,
+        createdAt: pending.createdAt,
+        phase: phase,
+        ...(phase === "ready" && pending.provisionalToken
+          ? { provisionalToken: pending.provisionalToken }
+          : {}),
+      },
     });
   });
 }
@@ -248,7 +257,9 @@ async function resumeTransfer() {
         return;
       }
       authenticated = true;
-      var auth = await startAuthFlow();
+      var auth = pending.provisionalToken
+        ? await validateAuthToken(pending.provisionalToken)
+        : await startAuthFlow(pending);
       if (auth.state === "cancelled" || auth.state === "rejected") {
         await clearPendingTransfer();
         notify("auth-cancelled", "authCancelledTitle", "authCancelledMessage");
@@ -287,7 +298,7 @@ async function resumeTransfer() {
   }
 }
 
-async function startAuthFlow() {
+async function startAuthFlow(pending) {
   var redirectURL = browser.identity.getRedirectURL();
   var authURL = apiURL + "/oauth2/authenticate";
   authURL += "?client_id=" + clientID;
@@ -306,6 +317,13 @@ async function startAuthFlow() {
     return { state: "rejected" };
   }
   if (!token) return { state: "rejected" };
+  // A temporary validation outage must not require repeating interactive OAuth.
+  // The provisional credential expires and clears with this one saved action.
+  await savePendingTransfer({ ...pending, provisionalToken: token }, "ready");
+  return validateAuthToken(token);
+}
+
+async function validateAuthToken(token) {
   var result = await validateToken(token);
   if (result !== "ready") {
     if (result === "unavailable") {

--- a/src/background.js
+++ b/src/background.js
@@ -46,7 +46,7 @@ browser.notifications.onClicked.addListener(function (notificationId) {
     return runOperation(async function () {
       var pending = await getPendingTransfer();
       if (pending && pending.phase !== "ready") {
-        await browser.storage.local.remove("pendingTransfer");
+        await clearPendingTransfer();
       }
     });
   }
@@ -121,11 +121,26 @@ function getToken() {
 var activeOperation = null;
 var operationGeneration = 0;
 var pendingMaxAge = 15 * 60 * 1000;
+var pendingStorage = Promise.resolve();
+
+// Keep expiry reads/removals ordered with new recovery writes. This queue owns
+// storage operations only; it never waits for network requests or sign-in.
+function updatePendingStorage(operation) {
+  var result = pendingStorage.then(operation);
+  pendingStorage = result.catch(function () {});
+  return result;
+}
+
+function clearPendingTransfer() {
+  return updatePendingStorage(function () {
+    return browser.storage.local.remove("pendingTransfer");
+  });
+}
 
 async function sendSelectedLink(link) {
   operationGeneration += 1;
   var token = await getToken();
-  var pending = (await browser.storage.local.get("pendingTransfer")).pendingTransfer;
+  var pending = await getPendingTransfer();
   if (!token || pending || activeOperation) {
     return runOperation(function () {
       return selectTransfer(link);
@@ -169,26 +184,30 @@ function runOperation(operation) {
   return activeOperation;
 }
 
-async function getPendingTransfer(clearExpired = true) {
-  var storage = await browser.storage.local.get("pendingTransfer");
-  var pending = storage.pendingTransfer;
-  if (!pending) return null;
-  if (
-    typeof pending.link !== "string" ||
-    !pending.link ||
-    !Number.isFinite(pending.createdAt) ||
-    Date.now() - pending.createdAt > pendingMaxAge ||
-    ["ready", "sending", "uncertain"].indexOf(pending.phase) < 0
-  ) {
-    if (clearExpired) await browser.storage.local.remove("pendingTransfer");
-    return null;
-  }
-  return pending;
+function getPendingTransfer(clearExpired = true) {
+  return updatePendingStorage(async function () {
+    var storage = await browser.storage.local.get("pendingTransfer");
+    var pending = storage.pendingTransfer;
+    if (!pending) return null;
+    if (
+      typeof pending.link !== "string" ||
+      !pending.link ||
+      !Number.isFinite(pending.createdAt) ||
+      Date.now() - pending.createdAt > pendingMaxAge ||
+      ["ready", "sending", "uncertain"].indexOf(pending.phase) < 0
+    ) {
+      if (clearExpired) await browser.storage.local.remove("pendingTransfer");
+      return null;
+    }
+    return pending;
+  });
 }
 
 function savePendingTransfer(pending, phase) {
-  return browser.storage.local.set({
-    pendingTransfer: { link: pending.link, createdAt: pending.createdAt, phase: phase },
+  return updatePendingStorage(function () {
+    return browser.storage.local.set({
+      pendingTransfer: { link: pending.link, createdAt: pending.createdAt, phase: phase },
+    });
   });
 }
 
@@ -224,14 +243,14 @@ async function resumeTransfer() {
   while (true) {
     if (!token) {
       if (authenticated) {
-        await browser.storage.local.remove("pendingTransfer");
+        await clearPendingTransfer();
         notify("auth-cancelled", "authCancelledTitle", "authCancelledMessage");
         return;
       }
       authenticated = true;
       var auth = await startAuthFlow();
       if (auth.state === "cancelled" || auth.state === "rejected") {
-        await browser.storage.local.remove("pendingTransfer");
+        await clearPendingTransfer();
         notify("auth-cancelled", "authCancelledTitle", "authCancelledMessage");
         return;
       }
@@ -244,7 +263,7 @@ async function resumeTransfer() {
     await savePendingTransfer(pending, "sending");
     var response = await startTransfer(token, pending.link);
     if (response && response.ok) {
-      await browser.storage.local.remove("pendingTransfer");
+      await clearPendingTransfer();
       return;
     }
     if (response && response.status === 401) {
@@ -257,7 +276,7 @@ async function resumeTransfer() {
       await savePendingTransfer(pending, "uncertain");
       notify("transfer-uncertain", "transferUncertainTitle", "transferUncertainMessage");
     } else {
-      await browser.storage.local.remove("pendingTransfer");
+      await clearPendingTransfer();
       notify(
         "transfer-start-failure",
         "transferFailureNotificationTitle",

--- a/tests/background.test.mjs
+++ b/tests/background.test.mjs
@@ -1,0 +1,324 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = fs.readFileSync(new URL("../src/background.js", import.meta.url), "utf8");
+const link = "https://example.invalid/selected.torrent";
+const response = (status) => ({ ok: status >= 200 && status < 300, status });
+
+function createHarness(options = {}) {
+  const state = options.state ?? {};
+  const events = {};
+  const calls = { auth: 0, validation: 0, transfers: [], notifications: [], tabs: [] };
+  const event = (name) => ({
+    addListener: (listener) => {
+      events[name] = listener;
+    },
+  });
+  const storage = {
+    get: async (key) => ({ [key]: structuredClone(state[key]) }),
+    set: async (values) => {
+      if (values.token && options.beforeTokenWrite) await options.beforeTokenWrite();
+      Object.assign(state, structuredClone(values));
+    },
+    remove: async (key) => {
+      delete state[key];
+    },
+  };
+  const browser = {
+    runtime: {
+      onInstalled: event("installed"),
+      onStartup: event("startup"),
+      getURL: (path) => path,
+    },
+    contextMenus: { onClicked: event("menu"), create: (_item, callback) => callback() },
+    action: { onClicked: event("toolbar") },
+    notifications: {
+      onClicked: event("notification"),
+      create: async (id, details) => {
+        calls.notifications.push({ id, ...details });
+      },
+      clear: async () => {},
+    },
+    tabs: {
+      create: async (details) => {
+        calls.tabs.push(details);
+      },
+    },
+    i18n: { getMessage: (key) => key },
+    storage: { local: storage },
+    identity: {
+      getRedirectURL: () => "https://extension.invalid/callback",
+      launchWebAuthFlow: async () => {
+        calls.auth += 1;
+        if (options.auth) return options.auth();
+        return "https://extension.invalid/callback#access_token=new-token&token_type=bearer";
+      },
+    },
+  };
+  const context = vm.createContext({
+    browser: options.chrome ? undefined : browser,
+    chrome: options.chrome ? browser : undefined,
+    console: { log() {}, error() {} },
+    URL,
+    URLSearchParams,
+    fetch: async (url, request) => {
+      if (url.endsWith("/oauth2/validate")) {
+        calls.validation += 1;
+        return options.validate ? options.validate() : response(200);
+      }
+      assert.ok(url.endsWith("/transfers/add"));
+      const transfer = { ...JSON.parse(request.body), token: request.headers.Authorization };
+      calls.transfers.push(transfer);
+      if (options.transfer) return options.transfer(transfer, state);
+      return response(200);
+    },
+  });
+  vm.runInContext(source, context);
+  return {
+    state,
+    calls,
+    click: async (url = link) => {
+      await events.menu({ menuItemId: "download-link", linkUrl: url }, {});
+      await new Promise(setImmediate);
+    },
+    startup: async () => {
+      await events.startup();
+      await new Promise(setImmediate);
+    },
+    notification: async (id) => {
+      await events.notification(id);
+      await new Promise(setImmediate);
+    },
+  };
+}
+
+for (const chrome of [false, true]) {
+  test(`resumes the exact selected link after durable authentication (${chrome ? "Chrome" : "Firefox"})`, async () => {
+    const app = createHarness({
+      chrome,
+      transfer: (_request, state) => {
+        assert.equal(state.token, "new-token");
+        assert.equal(state.pendingTransfer.phase, "sending");
+        return response(200);
+      },
+    });
+    await app.click();
+    assert.deepEqual(app.calls.transfers, [{ url: link, token: "token new-token" }]);
+    assert.equal(app.calls.auth, 1);
+    assert.equal(app.state.pendingTransfer, undefined);
+  });
+}
+
+test("does not send until token storage completes", async () => {
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const app = createHarness({ beforeTokenWrite: () => gate });
+  const result = app.click();
+  await new Promise(setImmediate);
+  assert.equal(app.calls.transfers.length, 0);
+  release();
+  await result;
+  assert.equal(app.calls.transfers.length, 1);
+});
+
+test("a second click cannot overwrite or replay the action being authenticated", async () => {
+  let finishAuth;
+  const auth = new Promise((resolve) => {
+    finishAuth = resolve;
+  });
+  const app = createHarness({ auth: () => auth });
+  const first = app.click();
+  await new Promise(setImmediate);
+  const second = app.click("https://example.invalid/other.torrent");
+  finishAuth("https://extension.invalid/callback#access_token=new-token");
+  await Promise.all([first, second]);
+  assert.deepEqual(
+    app.calls.transfers.map((transfer) => transfer.url),
+    [link],
+  );
+  assert.equal(app.calls.auth, 1);
+  assert.ok(app.calls.notifications.some((notice) => notice.title === "pendingTransferTitle"));
+});
+
+test("a rejected stored token authenticates once and retries only the rejected request", async () => {
+  const app = createHarness({
+    state: { token: "expired" },
+    transfer: (request) => response(request.token === "token expired" ? 401 : 200),
+  });
+  await app.click();
+  assert.deepEqual(
+    app.calls.transfers.map((request) => request.token),
+    ["token expired", "token new-token"],
+  );
+  assert.equal(app.calls.auth, 1);
+  assert.equal(app.state.pendingTransfer, undefined);
+});
+
+test("persistent token rejection ends authentication and clears the saved action", async () => {
+  const app = createHarness({ state: { token: "expired" }, transfer: () => response(401) });
+  await app.click();
+  assert.equal(app.calls.auth, 1);
+  assert.equal(app.calls.transfers.length, 2);
+  assert.equal(app.state.token, undefined);
+  assert.equal(app.state.pendingTransfer, undefined);
+});
+
+for (const unavailable of [
+  () => response(503),
+  () => {
+    throw new Error("offline");
+  },
+]) {
+  test("startup validation outages retain credentials without opening authentication", async () => {
+    const app = createHarness({
+      state: { token: "existing" },
+      validate: unavailable,
+      auth: () => {
+        throw new Error("fixture stops unexpected sign-in");
+      },
+    });
+    await app.startup();
+    assert.equal(app.calls.validation, 1);
+    assert.equal(app.calls.auth, 0);
+    assert.equal(app.state.token, "existing");
+  });
+  test("validation failure after authentication does not recursively sign in or send", async () => {
+    let attempts = 0;
+    const app = createHarness({
+      validate: unavailable,
+      auth: () => {
+        if (++attempts > 1) throw new Error("fixture bounds recursive sign-in");
+        return "https://extension.invalid/callback#access_token=new-token";
+      },
+    });
+    await app.click();
+    assert.equal(app.calls.auth, 1);
+    assert.equal(app.calls.validation, 1);
+    assert.equal(app.calls.transfers.length, 0);
+    assert.equal(app.state.pendingTransfer.link, link);
+  });
+}
+
+test("cancelling authentication clears the saved link", async () => {
+  const app = createHarness({
+    auth: () => {
+      throw new Error("cancelled");
+    },
+  });
+  await app.click();
+  assert.equal(app.state.pendingTransfer, undefined);
+  assert.equal(app.calls.transfers.length, 0);
+});
+
+test("a restarted worker retries a ready saved action only on explicit notification click", async () => {
+  const state = {
+    token: "existing",
+    pendingTransfer: { link, phase: "ready", createdAt: Date.now() },
+  };
+  const app = createHarness({ state });
+  await app.startup();
+  assert.equal(app.calls.transfers.length, 0);
+  await app.notification("auth-retry");
+  assert.deepEqual(
+    app.calls.transfers.map((request) => request.url),
+    [link],
+  );
+});
+
+for (const phase of ["sending", "uncertain"]) {
+  test(`worker restart never replays a ${phase} POST`, async () => {
+    const app = createHarness({
+      state: { token: "existing", pendingTransfer: { link, phase, createdAt: Date.now() } },
+    });
+    await app.startup();
+    await app.click();
+    await app.notification("auth-retry");
+    assert.equal(app.calls.transfers.length, 0);
+    await app.notification("transfer-uncertain");
+    assert.equal(app.calls.tabs[0].url, "https://app.put.io/transfers");
+    assert.equal(app.state.pendingTransfer, undefined);
+  });
+}
+
+for (const transfer of [
+  () => response(503),
+  () => {
+    throw new Error("offline");
+  },
+]) {
+  test("ambiguous transfer failures retain an uncertain action and never reauthenticate", async () => {
+    const app = createHarness({ state: { token: "existing" }, transfer });
+    await app.click();
+    assert.equal(app.calls.transfers.length, 1);
+    assert.equal(app.calls.auth, 0);
+    assert.equal(app.state.pendingTransfer.phase, "uncertain");
+  });
+}
+
+test("terminal transfer rejection clears the pending record", async () => {
+  const app = createHarness({ state: { token: "existing" }, transfer: () => response(400) });
+  await app.click();
+  assert.equal(app.state.pendingTransfer, undefined);
+  assert.equal(app.calls.auth, 0);
+});
+
+test("an abandoned saved link expires before another selected action", async () => {
+  const app = createHarness({
+    state: {
+      token: "existing",
+      pendingTransfer: { link, phase: "ready", createdAt: Date.now() - 16 * 60 * 1000 },
+    },
+  });
+  await app.click("https://example.invalid/new.torrent");
+  assert.equal(app.state.pendingTransfer, undefined);
+  assert.deepEqual(
+    app.calls.transfers.map((request) => request.url),
+    ["https://example.invalid/new.torrent"],
+  );
+});
+
+test("failed durable token storage leaves the action ready without sending", async () => {
+  const app = createHarness({
+    beforeTokenWrite: () => {
+      throw new Error("storage unavailable");
+    },
+  });
+  await app.click();
+  assert.equal(app.calls.transfers.length, 0);
+  assert.equal(app.state.token, undefined);
+  assert.equal(app.state.pendingTransfer.phase, "ready");
+});
+
+test("an old uncertain notification cannot discard a newer ready action", async () => {
+  const app = createHarness({
+    state: { token: "existing", pendingTransfer: { link, phase: "ready", createdAt: Date.now() } },
+  });
+  await app.notification("transfer-uncertain");
+  assert.equal(app.state.pendingTransfer.link, link);
+  assert.equal(app.calls.transfers.length, 0);
+});
+
+test("slow startup validation neither blocks a selected link nor removes its new token", async () => {
+  let finishValidation;
+  const oldValidation = new Promise((resolve) => {
+    finishValidation = resolve;
+  });
+  let validations = 0;
+  const app = createHarness({
+    state: { token: "expired" },
+    validate: () => (++validations === 1 ? oldValidation : response(200)),
+    transfer: (request) => response(request.token === "token expired" ? 401 : 200),
+  });
+  const startup = app.startup();
+  await new Promise(setImmediate);
+  await app.click();
+  finishValidation(response(401));
+  await startup;
+  assert.equal(app.state.token, "new-token");
+  assert.equal(app.calls.transfers.length, 2);
+  assert.equal(app.calls.auth, 1);
+});

--- a/tests/background.test.mjs
+++ b/tests/background.test.mjs
@@ -323,30 +323,37 @@ test("slow startup validation neither blocks a selected link nor removes its new
   assert.equal(app.calls.auth, 1);
 });
 
-test("signed-in links can start while an earlier transfer is still pending", async () => {
-  let finishFirst;
-  const pending = new Promise((resolve) => {
-    finishFirst = resolve;
+for (const expired of [false, true]) {
+  test(`signed-in links overlap after ${expired ? "expired recovery" : "ordinary selection"}`, async () => {
+    let finishFirst;
+    const pending = new Promise((resolve) => {
+      finishFirst = resolve;
+    });
+    const app = createHarness({
+      state: {
+        token: "existing",
+        ...(expired
+          ? { pendingTransfer: { link, phase: "ready", createdAt: Date.now() - 16 * 60 * 1000 } }
+          : {}),
+      },
+      transfer: (request) => (request.url === link ? pending : response(200)),
+    });
+    const first = app.click();
+    await new Promise(setImmediate);
+    const second = app.click("https://example.invalid/other.torrent");
+    await new Promise(setImmediate);
+    try {
+      assert.deepEqual(
+        app.calls.transfers.map((request) => request.url),
+        [link, "https://example.invalid/other.torrent"],
+      );
+      assert.equal(app.calls.auth, 0);
+    } finally {
+      finishFirst(response(200));
+      await Promise.all([first, second]);
+    }
   });
-  const app = createHarness({
-    state: { token: "existing" },
-    transfer: (request) => (request.url === link ? pending : response(200)),
-  });
-  const first = app.click();
-  await new Promise(setImmediate);
-  const second = app.click("https://example.invalid/other.torrent");
-  await new Promise(setImmediate);
-  try {
-    assert.deepEqual(
-      app.calls.transfers.map((request) => request.url),
-      [link, "https://example.invalid/other.torrent"],
-    );
-    assert.equal(app.calls.auth, 0);
-  } finally {
-    finishFirst(response(200));
-    await Promise.all([first, second]);
-  }
-});
+}
 
 test("rejected auth validation offers only terminal recovery", async () => {
   const app = createHarness({ validate: () => response(401) });

--- a/tests/background.test.mjs
+++ b/tests/background.test.mjs
@@ -251,10 +251,10 @@ for (const transfer of [
   },
 ]) {
   test("ambiguous transfer failures retain an uncertain action and never reauthenticate", async () => {
-    const app = createHarness({ state: { token: "existing" }, transfer });
+    const app = createHarness({ transfer });
     await app.click();
     assert.equal(app.calls.transfers.length, 1);
-    assert.equal(app.calls.auth, 0);
+    assert.equal(app.calls.auth, 1);
     assert.equal(app.state.pendingTransfer.phase, "uncertain");
   });
 }
@@ -321,4 +321,79 @@ test("slow startup validation neither blocks a selected link nor removes its new
   assert.equal(app.state.token, "new-token");
   assert.equal(app.calls.transfers.length, 2);
   assert.equal(app.calls.auth, 1);
+});
+
+test("signed-in links can start while an earlier transfer is still pending", async () => {
+  let finishFirst;
+  const pending = new Promise((resolve) => {
+    finishFirst = resolve;
+  });
+  const app = createHarness({
+    state: { token: "existing" },
+    transfer: (request) => (request.url === link ? pending : response(200)),
+  });
+  const first = app.click();
+  await new Promise(setImmediate);
+  const second = app.click("https://example.invalid/other.torrent");
+  await new Promise(setImmediate);
+  try {
+    assert.deepEqual(
+      app.calls.transfers.map((request) => request.url),
+      [link, "https://example.invalid/other.torrent"],
+    );
+    assert.equal(app.calls.auth, 0);
+  } finally {
+    finishFirst(response(200));
+    await Promise.all([first, second]);
+  }
+});
+
+test("rejected auth validation offers only terminal recovery", async () => {
+  const app = createHarness({ validate: () => response(401) });
+  await app.click();
+  assert.equal(app.state.pendingTransfer, undefined);
+  assert.equal(app.calls.transfers.length, 0);
+  assert.ok(app.calls.notifications.some((notice) => notice.id === "auth-cancelled"));
+  assert.equal(
+    app.calls.notifications.some((notice) => notice.id === "auth-retry"),
+    false,
+  );
+});
+
+for (const failure of [response(503), new Error("offline")]) {
+  test("late startup failure does not contradict a completed transfer", async () => {
+    let finishValidation;
+    const pending = new Promise((resolve, reject) => {
+      finishValidation = () => (failure instanceof Error ? reject(failure) : resolve(failure));
+    });
+    const app = createHarness({ state: { token: "existing" }, validate: () => pending });
+    const startup = app.startup();
+    await new Promise(setImmediate);
+    await app.click();
+    finishValidation();
+    await startup;
+    assert.equal(app.calls.transfers.length, 1);
+    assert.equal(
+      app.calls.notifications.some((notice) => notice.title === "authUnavailableTitle"),
+      false,
+    );
+  });
+}
+
+test("a worker woken by the start notification clears its interrupted send without replay", async () => {
+  const app = createHarness({
+    state: {
+      token: "existing",
+      pendingTransfer: { link, phase: "sending", createdAt: Date.now() },
+    },
+  });
+  await app.notification("transfer-start");
+  assert.equal(app.calls.tabs[0].url, "https://app.put.io/transfers");
+  assert.equal(app.state.pendingTransfer, undefined);
+  assert.equal(app.calls.transfers.length, 0);
+  await app.click("https://example.invalid/next.torrent");
+  assert.deepEqual(
+    app.calls.transfers.map((request) => request.url),
+    ["https://example.invalid/next.torrent"],
+  );
 });

--- a/tests/background.test.mjs
+++ b/tests/background.test.mjs
@@ -404,3 +404,70 @@ test("a worker woken by the start notification clears its interrupted send witho
     ["https://example.invalid/next.torrent"],
   );
 });
+
+for (const outage of [
+  () => response(503),
+  () => {
+    throw new Error("offline");
+  },
+]) {
+  test("explicit validation retries reuse the provisional OAuth token across worker restart", async () => {
+    const state = {};
+    const first = createHarness({ state, validate: outage });
+    await first.click();
+    assert.equal(first.calls.auth, 1);
+    assert.equal(state.token, undefined);
+    assert.equal(state.pendingTransfer.provisionalToken, "new-token");
+    await first.notification("auth-retry");
+    assert.equal(first.calls.auth, 1);
+    assert.equal(first.calls.validation, 2);
+    assert.equal(first.calls.transfers.length, 0);
+    const restarted = createHarness({ state });
+    await restarted.notification("auth-retry");
+    assert.equal(restarted.calls.auth, 0);
+    assert.equal(restarted.calls.validation, 1);
+    assert.deepEqual(restarted.calls.transfers, [{ url: link, token: "token new-token" }]);
+    assert.equal(state.pendingTransfer, undefined);
+  });
+}
+
+test("a rejected provisional credential clears recovery without another OAuth window", async () => {
+  const app = createHarness({
+    state: {
+      pendingTransfer: {
+        link,
+        phase: "ready",
+        createdAt: Date.now(),
+        provisionalToken: "rejected",
+      },
+    },
+    validate: () => response(401),
+  });
+  await app.notification("auth-retry");
+  assert.equal(app.calls.auth, 0);
+  assert.equal(app.calls.transfers.length, 0);
+  assert.equal(app.state.pendingTransfer, undefined);
+  assert.equal(app.state.token, undefined);
+  assert.equal(
+    app.calls.notifications.some((notice) => notice.id === "auth-retry"),
+    false,
+  );
+});
+
+test("an expired provisional credential is cleared without validation or sign-in", async () => {
+  const app = createHarness({
+    state: {
+      pendingTransfer: {
+        link,
+        phase: "ready",
+        createdAt: Date.now() - 16 * 60 * 1000,
+        provisionalToken: "expired",
+      },
+    },
+  });
+  await app.notification("auth-retry");
+  assert.equal(app.calls.auth, 0);
+  assert.equal(app.calls.validation, 0);
+  assert.equal(app.calls.transfers.length, 0);
+  assert.equal(app.state.pendingTransfer, undefined);
+});


### PR DESCRIPTION
## Summary

Selecting a link while signed out saves that one link, and completing sign-in sends it once. Recovery survives a validation outage after OAuth by keeping the provisional token, so an explicit retry validates it instead of reopening sign-in. Cancellation, rejection, completion, and a 15-minute expiry clear the saved link.

Signed-in downloads still overlap. A transfer POST interrupted by a worker restart is never resent; its notification opens the transfers page and clears the saved link. Startup validation cannot discard a token obtained by a newer user action.

## Verification

- `pnpm run check` (lint plus 31 background-flow tests with mocked browser and HTTP boundaries) and both extension builds pass
- Each regression test fails before its fix
- Installed Chromium MV3 with real storage and mocked identity/network: overlapping sends, exact-link recovery, token stored before POST, one OAuth window across validation retries, success cleanup, no replay of an uncertain send

## Not verified

Manual Firefox behavior and real OAuth/context-menu acceptance. Firefox loaded the temporary MV2 build but inspection stopped on its `script.getRealms` internal error.